### PR TITLE
Reduced vue-gwt dependency to 1 version

### DIFF
--- a/gwt-client-geo-ol3-vue/pom.xml
+++ b/gwt-client-geo-ol3-vue/pom.xml
@@ -27,22 +27,6 @@
   <name>AERIUS :: geo GWT client for OL3 Vue</name>
   <packaging>gwt-lib</packaging>
 
-  <properties>
-    <vue.version>1.0-beta-10-AERIUS</vue.version>
-  </properties>
-
-  <repositories>
-    <!-- Using a patch repo on github containing unreleased patches, can be removed when release with patches is available -->
-    <repository>
-      <id>vue-gwt-aerius-patch-repo</id>
-      <url>https://raw.github.com/JornC/vue-gwt/aerius-patch-repo/</url>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>nl.aerius</groupId>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>gwt-client-common-parent</artifactId>
     <version>1.3.0-SNAPSHOT</version>
   </parent>
+
   <artifactId>gwt-client-geo-ol3</artifactId>
   <name>AERIUS :: geo GWT client for OL3</name>
 

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -30,17 +30,6 @@
   <name>AERIUS :: GWT library for GWTVue</name>
   <description>Simple wrapper to easier use VueGwt in conjunction with typical GWT setups.</description>
 
-  <properties>
-    <vue.version>1.0-beta-10-YOGH</vue.version>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>vue-gwt-yogh-patch-repo</id>
-      <url>https://raw.github.com/JornC/vue-gwt/mvn-repo/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>nl.aerius</groupId>

--- a/gwt-client-vuelidate/demo/demo-client/pom.xml
+++ b/gwt-client-vuelidate/demo/demo-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-demo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo-client</artifactId>

--- a/gwt-client-vuelidate/demo/demo-server/pom.xml
+++ b/gwt-client-vuelidate/demo/demo-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-demo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo-server</artifactId>

--- a/gwt-client-vuelidate/demo/pom.xml
+++ b/gwt-client-vuelidate/demo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo</artifactId>

--- a/gwt-client-vuelidate/pom.xml
+++ b/gwt-client-vuelidate/pom.xml
@@ -28,17 +28,6 @@
 
   <name>AERIUS :: gwt-vuelidate-parent</name>
 
-  <repositories>
-    <repository>
-      <id>vue-gwt-yogh-patch-repo</id>
-      <url>https://raw.github.com/JornC/vue-gwt/mvn-repo/</url>
-    </repository>
-  </repositories>
-
-  <properties>
-    <vue.version>1.0-beta-10-YOGH</vue.version>
-  </properties>
-
   <profiles>
     <profile>
       <id>default</id>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>8</java.version>
 
+    <vue.version>1.0-beta-10-AERIUS</vue.version>
+
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <com.google.gwt.version>2.8.2</com.google.gwt.version>
 


### PR DESCRIPTION
Removed 1.0-beta-10-YOGH.
Updated vuelidate demo project version number. Although it seems these demos don't compile at the moment.