### PR TITLE
prepare for version 1.4, with an upgrade to java 11

### DIFF
--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -19,5 +19,4 @@ jobs:
       - uses: aerius/github-actions/events/pull_request-event-action@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JDK_VERSION: 1.8
 

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -21,5 +21,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          JDK_VERSION: 1.8
 

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -22,5 +22,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          JDK_VERSION: 1.8
 

--- a/gwt-client-common/pom.xml
+++ b/gwt-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-common</artifactId>
   <name>AERIUS :: Common GWT Client</name>

--- a/gwt-client-geo-ol3-vue/pom.xml
+++ b/gwt-client-geo-ol3-vue/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-geo-ol3-vue</artifactId>
   <name>AERIUS :: geo GWT client for OL3 Vue</name>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-geo-ol3</artifactId>

--- a/gwt-client-geo/pom.xml
+++ b/gwt-client-geo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-geo</artifactId>
   <name>AERIUS :: geo GWT client</name>

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-vue</artifactId>

--- a/gwt-client-vuelidate/demo/demo-client/pom.xml
+++ b/gwt-client-vuelidate/demo/demo-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-demo</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo-client</artifactId>

--- a/gwt-client-vuelidate/demo/demo-server/pom.xml
+++ b/gwt-client-vuelidate/demo/demo-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-demo</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo-server</artifactId>

--- a/gwt-client-vuelidate/demo/pom.xml
+++ b/gwt-client-vuelidate/demo/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate-demo</artifactId>

--- a/gwt-client-vuelidate/pom.xml
+++ b/gwt-client-vuelidate/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-vuelidate-parent</artifactId>
   <packaging>pom</packaging>

--- a/gwt-client-vuelidate/sources/pom.xml
+++ b/gwt-client-vuelidate/sources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-vuelidate</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>gwt-client-common-parent</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AERIUS :: Common GWT Client Parent</name>
   <url>https://www.aerius.nl</url>
@@ -58,7 +58,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>8</java.version>
+    <java.version>11</java.version>
 
     <vue.version>1.0-beta-10-AERIUS</vue.version>
 


### PR DESCRIPTION
this is in preparation for https://github.com/aerius/gwt-client-common/pull/6, which changes a lot and depends on imaer-java which is compiled with java 11. 