### PR TITLE
Add maystop ability to delegated activities

### DIFF
--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
@@ -63,6 +63,13 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
       return;
     }
 
+    if (!mayDelegateToActivity(currentActivity)) {
+      GWTProd.log("ActivityManager", "Cancelling because delegated activity won't stop.");
+      c.silence();
+      c.cancel();
+      return;
+    }
+
     final boolean delegateSuccess = delegateToActivity(currentActivity, activityEventBus, c);
     if (delegateSuccess) {
       GWTProd.log("ActivityManager", "Delegated to current activity.");
@@ -109,6 +116,26 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
         act.delegate(activityEventBus, c);
       }
     }
+  }
+
+  private boolean mayDelegateToActivity(final Activity<?, ?> activity) {
+    if (activity instanceof DelegableActivity) {
+      final DelegableActivity delegated = (DelegableActivity) activity;
+
+      final String stop = delegated.mayStop();
+      if (stop != null) {
+        final boolean confirm = Window.confirm(stop);
+        if (confirm) {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        return true;
+      }
+    }
+
+    return true;
   }
 
   private boolean delegateToActivity(final Activity<?, ?> activity, final ResettableEventBus eventBus, final PlaceChangeCommand c) {

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
@@ -124,14 +124,7 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
 
       final String stop = delegated.mayStop();
       if (stop != null) {
-        final boolean confirm = Window.confirm(stop);
-        if (confirm) {
-          return true;
-        } else {
-          return false;
-        }
-      } else {
-        return true;
+        return Window.confirm(stop);
       }
     }
 

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/DelegableActivity.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/DelegableActivity.java
@@ -29,4 +29,8 @@ public interface DelegableActivity {
   default boolean isDelegable(final Place place) {
     return false;
   }
+
+  default String mayStop() {
+    return null;
+  }
 }


### PR DESCRIPTION
This changes nothing by default, but allows delegated activities to implement a `String mayStop()` like a parent activity might, and stop the place change.