### PR TITLE
Allow retrieval of the current activity

### DIFF
--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
@@ -40,23 +40,19 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
   private final PlaceController placeController;
 
   private C panel;
+  private final ActivityContext activityContext;
 
   private final ResettableEventBus activityEventBus;
 
-  private Activity<?, ?> currentActivity;
-
-  public AbstractActivityManager(final EventBus globalEventBus, final PlaceController placeController, final ActivityMapper<C> mapper) {
+  public AbstractActivityManager(final EventBus globalEventBus, final PlaceController placeController, final ActivityMapper<C> mapper,
+      final ActivityContext activityContext) {
     this.placeController = placeController;
     this.mapper = mapper;
+    this.activityContext = activityContext;
 
     activityEventBus = new ResettableEventBus(globalEventBus);
 
     EVENT_BINDER.bindEventHandlers(this, globalEventBus);
-  }
-
-  @Override
-  public Activity<?, ?> getCurrentActivity() {
-    return currentActivity;
   }
 
   @EventHandler
@@ -68,6 +64,7 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
       return;
     }
 
+    final Activity<?, ?> currentActivity = activityContext.getActivity();
     if (!mayDelegateToActivity(currentActivity)) {
       GWTProd.log("ActivityManager", "Cancelling because delegated activity won't stop.");
       c.silence();
@@ -105,9 +102,9 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
       ((HasEventBus) activity).setEventBus(activityEventBus);
     }
 
-    currentActivity = activity;
+    activityContext.setActivity(activity);
 
-    GWTProd.log("ActivityManager", "Starting activity: " + currentActivity.getClass().getSimpleName());
+    GWTProd.log("ActivityManager", "Starting activity: " + activity.getClass().getSimpleName());
 
     // Start and delegate
     activity.onStart(panel);

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/AbstractActivityManager.java
@@ -54,6 +54,11 @@ public abstract class AbstractActivityManager<C> implements ActivityManager<C> {
     EVENT_BINDER.bindEventHandlers(this, globalEventBus);
   }
 
+  @Override
+  public Activity<?, ?> getCurrentActivity() {
+    return currentActivity;
+  }
+
   @EventHandler
   public void onPlaceChangeCommand(final PlaceChangeCommand c) {
     final Place previousPlace = placeController.getPreviousPlace();

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityContext.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityContext.java
@@ -16,16 +16,17 @@
  */
 package nl.aerius.wui.activity;
 
-import com.google.gwt.user.client.ui.AcceptsOneWidget;
-import com.google.inject.Inject;
-import com.google.web.bindery.event.shared.EventBus;
+import javax.inject.Singleton;
 
-import nl.aerius.wui.place.PlaceController;
+@Singleton
+public class ActivityContext {
+  private Activity<?, ?> activity;
 
-public class WidgetActivityManager extends AbstractActivityManager<AcceptsOneWidget> {
-  @Inject
-  public WidgetActivityManager(final EventBus globalEventBus, final PlaceController placeController, final ActivityMapper<AcceptsOneWidget> mapper,
-      final ActivityContext activityContext) {
-    super(globalEventBus, placeController, mapper, activityContext);
+  public void setActivity(final Activity<?, ?> activity) {
+    this.activity = activity;
+  }
+
+  public Activity<?, ?> getActivity() {
+    return activity;
   }
 }

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityManager.java
@@ -21,8 +21,4 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(WidgetActivityManager.class)
 public interface ActivityManager<C> {
   void setPanel(C panel);
-
-  default Activity<?, ?> getCurrentActivity() {
-    return null;
-  }
 }

--- a/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityManager.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/activity/ActivityManager.java
@@ -21,4 +21,8 @@ import com.google.inject.ImplementedBy;
 @ImplementedBy(WidgetActivityManager.class)
 public interface ActivityManager<C> {
   void setPanel(C panel);
+
+  default Activity<?, ?> getCurrentActivity() {
+    return null;
+  }
 }

--- a/gwt-client-vue/src/main/java/nl/aerius/wui/vue/activity/VueActivityManager.java
+++ b/gwt-client-vue/src/main/java/nl/aerius/wui/vue/activity/VueActivityManager.java
@@ -20,13 +20,15 @@ import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
 import nl.aerius.wui.activity.AbstractActivityManager;
+import nl.aerius.wui.activity.ActivityContext;
 import nl.aerius.wui.activity.ActivityMapper;
 import nl.aerius.wui.place.PlaceController;
 import nl.aerius.wui.vue.AcceptsOneComponent;
 
 public class VueActivityManager extends AbstractActivityManager<AcceptsOneComponent> {
   @Inject
-  public VueActivityManager(final EventBus globalEventBus, final PlaceController placeController, final ActivityMapper<AcceptsOneComponent> mapper) {
-    super(globalEventBus, placeController, mapper);
+  public VueActivityManager(final EventBus globalEventBus, final PlaceController placeController, final ActivityMapper<AcceptsOneComponent> mapper,
+      final ActivityContext activityContext) {
+    super(globalEventBus, placeController, mapper, activityContext);
   }
 }


### PR DESCRIPTION
Letting ActivityManager return the current activity creates likely dependency cycles, so opted to use an ActivityContext singleton which can be injected by dependents.