### PR TITLE
Make VectorDirective more robust

### DIFF
--- a/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
+++ b/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
@@ -61,7 +61,7 @@ public class VectorDirective extends VueDirective {
           final Attr attr = Js.cast(el.attributes.get(v).cloneNode(true));
 
           final Node node = el.childNodes.getAt(0);
-          if (node.hasAttributes()) {
+          if (node != null && node.hasAttributes()) {
             node.attributes.setNamedItem(attr);
 
             final Element elem = Js.uncheckedCast(node);


### PR DESCRIPTION
It is possible for the node to be null when this directive is improperly used, so nullcheck it and fall back to the existing warning/log clause.