### PR TITLE
Remove deprecated init method

### DIFF
--- a/gwt-client-geo-ol3/src/main/java/nl/aerius/geo/wui/MapLayoutPanel.java
+++ b/gwt-client-geo-ol3/src/main/java/nl/aerius/geo/wui/MapLayoutPanel.java
@@ -77,7 +77,6 @@ import nl.aerius.geo.wui.util.OL3MapUtil;
 import nl.aerius.wui.command.Command;
 import nl.aerius.wui.event.HasEventBus;
 import nl.aerius.wui.util.SchedulerUtil;
-import nl.overheid.aerius.geo.shared.EPSG;
 
 /**
  * Manages the events to a OpenLayers map.
@@ -96,21 +95,6 @@ public class MapLayoutPanel implements HasEventBus {
 
   private boolean deferredZoomScheduled;
   private HandlerRegistration handlers;
-
-  /**
-   * Constructs the map for the given projection.
-   *
-   * This method should be called once and would have done in the constructor if
-   * epsg would not be dynamic. If epsg will be made static, as in available at
-   * startup, this code could be moved to a constructor.
-   *
-   * @param epsg projection.
-   * @deprecated use {@link #init(MapProperties)} to avoid using the deprecated EPSG class
-   */
-  @Deprecated
-  public void init(final EPSG epsg) {
-    init(new MapProperties(epsg.getEpsgCode(), epsg.getBounds(), epsg.getCenter().getX(), epsg.getCenter().getY(), epsg.getZoomLevel()));
-  }
 
   /**
    * Constructs the map for the given projection.

--- a/gwt-shared-geo-common/pom.xml
+++ b/gwt-shared-geo-common/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>shared-geo</artifactId>
-      <version>5.1.0-1</version>
+      <version>5.1.0-2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Also updated version of shared-geo library (where the deprecated class was removed as well).