### PR TITLE
Revert update to new VueGWT and Elemental

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-common-bom</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-common-bom</artifactId>

--- a/gwt-client-common-json/pom.xml
+++ b/gwt-client-common-json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-common-json</artifactId>

--- a/gwt-client-common-json/pom.xml
+++ b/gwt-client-common-json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-common-json</artifactId>

--- a/gwt-client-common/pom.xml
+++ b/gwt-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-common</artifactId>
   <name>AERIUS :: Common GWT Client</name>

--- a/gwt-client-common/pom.xml
+++ b/gwt-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-common</artifactId>
   <name>AERIUS :: Common GWT Client</name>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-geo-ol3</artifactId>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.github.tdesjardins</groupId>
       <artifactId>gwt-ol3</artifactId>
-      <version>8.2.0</version>
+      <version>8.0.0</version>
       <type>gwt-lib</type>
     </dependency>
     <dependency>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-geo-ol3</artifactId>

--- a/gwt-client-geo/pom.xml
+++ b/gwt-client-geo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-geo</artifactId>
   <name>AERIUS :: geo GWT client</name>

--- a/gwt-client-geo/pom.xml
+++ b/gwt-client-geo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-client-geo</artifactId>
   <name>AERIUS :: geo GWT client</name>

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-vue</artifactId>

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-vue</artifactId>

--- a/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
+++ b/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
@@ -55,7 +55,7 @@ public class VectorDirective extends VueDirective {
     el.innerHTML = str;
 
     // Clone the data elements if any
-    final List<Node> dataAttributes = Stream.of(el.getAttributeNames().asArray(new String[0]))
+    final List<Node> dataAttributes = Stream.of(el.getAttributeNames())
         .filter(v -> v.startsWith("data-"))
         .map(v -> (Node) Js.cast(el.attributes.get(v).cloneNode(true)))
         .collect(Collectors.toList());

--- a/gwt-shared-geo-common/pom.xml
+++ b/gwt-shared-geo-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-shared-geo-common</artifactId>

--- a/gwt-shared-geo-common/pom.xml
+++ b/gwt-shared-geo-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-shared-geo-common</artifactId>

--- a/gwt-vuelidate/pom.xml
+++ b/gwt-vuelidate/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-vuelidate-parent</artifactId>
   <packaging>pom</packaging>

--- a/gwt-vuelidate/pom.xml
+++ b/gwt-vuelidate/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-vuelidate-parent</artifactId>
   <packaging>pom</packaging>

--- a/gwt-vuelidate/sources/pom.xml
+++ b/gwt-vuelidate/sources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-vuelidate</artifactId>

--- a/gwt-vuelidate/sources/pom.xml
+++ b/gwt-vuelidate/sources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>gwt-client-vuelidate</artifactId>

--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidateDirective.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidateDirective.java
@@ -24,7 +24,6 @@ import com.axellience.vuegwt.core.client.directive.VueDirective;
 import com.axellience.vuegwt.core.client.vnode.VNode;
 import com.axellience.vuegwt.core.client.vnode.VNodeDirective;
 
-import elemental2.core.JsArray;
 import elemental2.core.JsObject;
 import elemental2.dom.Element;
 
@@ -43,11 +42,11 @@ public class ValidateDirective extends VueDirective {
 
     @SuppressWarnings("unchecked")
     final Validations vals = Js.uncheckedCast(((JsPropertyMap<Object>) jsContext.get("$v")).get(runtimeProperty));
-    final JsArray<String> modifiers = JsObject.getOwnPropertyNames(binding.getModifiers());
+    final String[] modifiers = JsObject.getOwnPropertyNames(binding.getModifiers());
 
     // Touch the validation on blur (to update it)
     // This circumvents binding to the validation model
-    el.addEventListener(modifiers.length > 0 ? modifiers.getAt(0) : "blur", e -> {
+    el.addEventListener(modifiers.length > 0 ? modifiers[0] : "blur", e -> {
       vals.$touch();
     });
   }

--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/VuelidateUtil.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/VuelidateUtil.java
@@ -20,15 +20,12 @@ import java.util.Map;
 
 import com.axellience.vuegwt.core.client.component.IsVueComponent;
 
+import elemental2.core.JsObject;
+
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 
-public final class VuelidateUtil {
-
-  private VuelidateUtil() {
-    // Util class.
-  }
-
+public class VuelidateUtil {
   /**
    * Proxy a given field with the contents of another field
    */
@@ -36,7 +33,12 @@ public final class VuelidateUtil {
     final JsPropertyMap<Object> options = Js.cast(instance);
     final JsPropertyMap<Object> validations = Js.cast(options.get("$v"));
 
-    validations.set(field, Js.cast(validations.get(runtime)));
+    final JsPropertyMap<Object> obj = JsPropertyMap.of();
+    final JsObject receive = Js.cast(validations.get(runtime));
+    JsObject.assign(obj, receive);
+    final Object finall = obj.get("0");
+
+    validations.set(field, finall);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
 
-    <vue.version>1.0.1</vue.version>
+    <vue.version>1.0-beta-10-AERIUS</vue.version>
 
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <com.google.gwt.version>2.10.0</com.google.gwt.version>
@@ -91,12 +91,12 @@
       <dependency>
         <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-core</artifactId>
-        <version>1.1.0</version>
+        <version>1.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-dom</artifactId>
-        <version>1.1.0</version>
+        <version>1.0.0-RC1</version>
       </dependency>
       <dependency>
         <groupId>com.axellience</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>gwt-client-common-parent</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AERIUS :: Common GWT Client Parent</name>
   <url>https://www.aerius.nl</url>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>gwt-client-common-parent</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AERIUS :: Common GWT Client Parent</name>
   <url>https://www.aerius.nl</url>


### PR DESCRIPTION
- Go to 1.6.1-SNAPSHOT so current uses of 1.6.0-SNAPSHOT don't break