### PR TITLE
Update GWT group ids

### DIFF
--- a/gwt-client-common-json/pom.xml
+++ b/gwt-client-common-json/pom.xml
@@ -32,12 +32,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/gwt-client-common/pom.xml
+++ b/gwt-client-common/pom.xml
@@ -30,12 +30,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -36,7 +36,7 @@
       <type>gwt-lib</type>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/gwt-client-geo/pom.xml
+++ b/gwt-client-geo/pom.xml
@@ -30,12 +30,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -50,12 +50,12 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <vue.version>1.0-beta-10-AERIUS</vue.version>
 
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-    <com.google.gwt.version>2.10.0</com.google.gwt.version>
+    <org.gwtproject.version>2.10.0</org.gwtproject.version>
 
     <aerius-tools.version>1.1.1</aerius-tools.version>
     <spotless.version>2.5.0</spotless.version>
@@ -72,9 +72,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt</artifactId>
-        <version>${com.google.gwt.version}</version>
+        <version>${org.gwtproject.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Since 2.10 the gwtproject org one is preferred, the com.google one will be phased out with the next release