### PR TITLE
AER-2434 Remove custom GWT-vue component

### DIFF
--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.github.tdesjardins</groupId>
       <artifactId>gwt-ol3</artifactId>
-      <version>8.0.0</version>
+      <version>8.4.1</version>
       <type>gwt-lib</type>
     </dependency>
     <dependency>

--- a/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
+++ b/gwt-client-vue/src/main/java/nl/aerius/wui/vue/directives/VectorDirective.java
@@ -55,7 +55,7 @@ public class VectorDirective extends VueDirective {
     el.innerHTML = str;
 
     // Clone the data elements if any
-    final List<Node> dataAttributes = Stream.of(el.getAttributeNames())
+    final List<Node> dataAttributes = Stream.of(el.getAttributeNames().asArray(new String[0]))
         .filter(v -> v.startsWith("data-"))
         .map(v -> (Node) Js.cast(el.attributes.get(v).cloneNode(true)))
         .collect(Collectors.toList());

--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidateDirective.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidateDirective.java
@@ -24,6 +24,7 @@ import com.axellience.vuegwt.core.client.directive.VueDirective;
 import com.axellience.vuegwt.core.client.vnode.VNode;
 import com.axellience.vuegwt.core.client.vnode.VNodeDirective;
 
+import elemental2.core.JsArray;
 import elemental2.core.JsObject;
 import elemental2.dom.Element;
 
@@ -42,11 +43,11 @@ public class ValidateDirective extends VueDirective {
 
     @SuppressWarnings("unchecked")
     final Validations vals = Js.uncheckedCast(((JsPropertyMap<Object>) jsContext.get("$v")).get(runtimeProperty));
-    final String[] modifiers = JsObject.getOwnPropertyNames(binding.getModifiers());
+    final JsArray<String> modifiers = JsObject.getOwnPropertyNames(binding.getModifiers());
 
     // Touch the validation on blur (to update it)
     // This circumvents binding to the validation model
-    el.addEventListener(modifiers.length > 0 ? modifiers[0] : "blur", e -> {
+    el.addEventListener(modifiers.length > 0 ? modifiers.getAt(0) : "blur", e -> {
       vals.$touch();
     });
   }

--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/ValidationUtil.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/ValidationUtil.java
@@ -47,7 +47,8 @@ public final class ValidationUtil {
       if (value == null || value.isEmpty()) {
         consumer.accept(_default);
       } else {
-        final double doubleValue = Double.valueOf(value);
+        final double doubleValue = Double.parseDouble(value);
+
         if (!Double.isNaN(doubleValue)) {
           consumer.accept(doubleValue);
         }

--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/VuelidateUtil.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/util/VuelidateUtil.java
@@ -20,12 +20,15 @@ import java.util.Map;
 
 import com.axellience.vuegwt.core.client.component.IsVueComponent;
 
-import elemental2.core.JsObject;
-
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 
-public class VuelidateUtil {
+public final class VuelidateUtil {
+
+  private VuelidateUtil() {
+    // Util class.
+  }
+
   /**
    * Proxy a given field with the contents of another field
    */
@@ -33,12 +36,7 @@ public class VuelidateUtil {
     final JsPropertyMap<Object> options = Js.cast(instance);
     final JsPropertyMap<Object> validations = Js.cast(options.get("$v"));
 
-    final JsPropertyMap<Object> obj = JsPropertyMap.of();
-    final JsObject receive = Js.cast(validations.get(runtime));
-    JsObject.assign(obj, receive);
-    final Object finall = obj.get("0");
-
-    validations.set(field, finall);
+    validations.set(field, Js.cast(validations.get(runtime)));
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
 
-    <vue.version>1.0-beta-10-AERIUS</vue.version>
+    <vue.version>1.0.1</vue.version>
 
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <org.gwtproject.version>2.10.0</org.gwtproject.version>
+    <elemental2.verion>1.1.0</elemental2.verion>
 
     <aerius-tools.version>1.1.1</aerius-tools.version>
     <spotless.version>2.5.0</spotless.version>
@@ -79,6 +80,21 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>6.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>6.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.3-jre</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.gwt.inject</groupId>
         <artifactId>gin</artifactId>
         <version>2.1.2</version>
@@ -91,12 +107,12 @@
       <dependency>
         <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-core</artifactId>
-        <version>1.0.0-RC1</version>
+        <version>${elemental2.verion}</version>
       </dependency>
       <dependency>
         <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-dom</artifactId>
-        <version>1.0.0-RC1</version>
+        <version>${elemental2.verion}</version>
       </dependency>
       <dependency>
         <groupId>com.axellience</groupId>


### PR DESCRIPTION
Updated vue-gwt, gwt-ol3, and elemental2 to newer versions to make code compatible with Java 17.

Also added dependency updates of guice and guava to make compiling/working on Java 17 possible (fixes `com.google.inject.internal.util.$ComputationException: java.lang.ExceptionInInitializerError` error:
See also https://github.com/rstudio/rstudio/issues/11242 and fix that was created: https://github.com/rstudio/rstudio/pull/13963)