### PR TITLE
Update version to 1.8.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-client-common-bom</artifactId>

--- a/gwt-client-common-json/pom.xml
+++ b/gwt-client-common-json/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-client-common-json</artifactId>

--- a/gwt-client-common/pom.xml
+++ b/gwt-client-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
   <artifactId>gwt-client-common</artifactId>
   <name>AERIUS :: Common GWT Client</name>

--- a/gwt-client-geo-ol3/pom.xml
+++ b/gwt-client-geo-ol3/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-client-geo-ol3</artifactId>

--- a/gwt-client-geo/pom.xml
+++ b/gwt-client-geo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
   <artifactId>gwt-client-geo</artifactId>
   <name>AERIUS :: geo GWT client</name>

--- a/gwt-client-vue/pom.xml
+++ b/gwt-client-vue/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-client-vue</artifactId>

--- a/gwt-shared-geo-common/pom.xml
+++ b/gwt-shared-geo-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-shared-geo-common</artifactId>

--- a/gwt-vuelidate/pom.xml
+++ b/gwt-vuelidate/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-client-common-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
   <artifactId>gwt-vuelidate-parent</artifactId>
   <packaging>pom</packaging>

--- a/gwt-vuelidate/sources/pom.xml
+++ b/gwt-vuelidate/sources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>gwt-vuelidate-parent</artifactId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.8.1</version>
   </parent>
 
   <artifactId>gwt-client-vuelidate</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>gwt-client-common-parent</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>1.8.1</version>
   <packaging>pom</packaging>
   <name>AERIUS :: Common GWT Client Parent</name>
   <url>https://www.aerius.nl</url>


### PR DESCRIPTION
The change seems to be trivial enough and should not break backwards-compatibility. So I opted for a minor version bump. 