### PR TITLE
On production log error of GWTProd to server, add explicit timeout to xmlhttp request

### DIFF
--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/util/RequestUtil.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/util/RequestUtil.java
@@ -29,7 +29,9 @@ import elemental2.dom.XMLHttpRequest;
 
 import nl.aerius.wui.exception.HttpRequestException;
 
-public class RequestUtil {
+public final class RequestUtil {
+
+  private static final int XML_HTTP_REQUEST_TIMEOUT_MS = 10_000;
 
   private RequestUtil() {
     // Util class
@@ -140,6 +142,7 @@ public class RequestUtil {
     addEventListeners(req, callback);
 
     req.open(method, url);
+    req.timeout = XML_HTTP_REQUEST_TIMEOUT_MS;
     additionalHeaders.forEach(req::setRequestHeader);
     return req;
   }

--- a/gwt-client-common/src/main/java/nl/aerius/wui/dev/GWTProd.java
+++ b/gwt-client-common/src/main/java/nl/aerius/wui/dev/GWTProd.java
@@ -16,12 +16,16 @@
  */
 package nl.aerius.wui.dev;
 
+import java.util.logging.Logger;
+
 import elemental2.dom.DomGlobal;
 
 /**
  * Apparently varargs don't work swimmingly, so implement a bunch of overloads instead.
  */
 public final class GWTProd {
+  private static final Logger LOGGER = Logger.getLogger("GWTProd");
+
   private static boolean dev = true;
 
   private GWTProd() {}
@@ -71,21 +75,37 @@ public final class GWTProd {
   }
 
   public static void error(final Object msg) {
-    DomGlobal.console.warn(msg);
+    if (dev) {
+      DomGlobal.console.error(msg);
+    } else {
+      LOGGER.severe(safeObjecString(msg));
+    }
     tryReport(msg);
   }
 
   public static void error(final Object a, final Object b) {
-    DomGlobal.console.error(a, b);
+    if (dev) {
+      DomGlobal.console.error(a, b);
+    } else {
+      LOGGER.severe(safeObjecString(a) + "-" + safeObjecString(b));
+    }
     tryReport(a);
     tryReport(b);
   }
 
   public static void error(final Object a, final Object b, final Object c) {
-    DomGlobal.console.error(a, b, c);
+    if (dev) {
+      DomGlobal.console.error(a, b, c);
+    } else {
+      LOGGER.severe(safeObjecString(a) + "-" + safeObjecString(b) + "-" + safeObjecString(c));
+    }
     tryReport(a);
     tryReport(b);
     tryReport(c);
+  }
+
+  private static String safeObjecString(final Object msg) {
+    return msg == null ? "null" : msg.toString();
   }
 
   private static void tryReport(final Object ex) {


### PR DESCRIPTION
- In GWTProd when on production log to standard logging, this will make sure the log is sent to the server. Useful in case of errors happening in the browser.
- Added an explicit (arbitrary) timeout to xml http request to make sure in case the server hangs it will exit at some point.