### PR TITLE
Support Double's special cases

### DIFF
--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONNumericParser.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONNumericParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
 package nl.aerius.wui.service.json;
 
 import com.google.gwt.json.client.JSONNumber;

--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONValueHandle.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONValueHandle.java
@@ -30,46 +30,109 @@ public class JSONValueHandle {
   }
 
   public boolean isString() {
-    return inner.isString() != null;
+    return inner != null && inner.isString() != null;
   }
 
   public String asString() {
+    if (inner == null || inner.isString() == null) {
+      throw new IllegalStateException("Value is not a String");
+    }
     return inner.isString().stringValue();
   }
 
+  /**
+   * Returns the integer value of this JSONValue.
+   * Delegates to asNumber() and casts the result to int.
+   * 
+   * @return The integer value.
+   * @throws IllegalStateException if the value cannot be converted to a number.
+   */
   public Integer asInteger() {
-    return (int) inner.isNumber().doubleValue();
+    // Rely on asNumber for parsing logic (including strings like "Infinity")
+    // Note: Casting Infinity/NaN to int results in Integer.MAX_VALUE/MIN_VALUE/0
+    // respectively.
+    return asNumber().intValue();
   }
 
+  /**
+   * Returns the double value of this JSONValue.
+   * Uses JsonNumericParser to handle JSONNumber and special strings ("Infinity",
+   * etc.).
+   *
+   * @return The double value.
+   * @throws IllegalStateException if the value cannot be converted to a number.
+   */
   public Double asNumber() {
-    return inner.isNumber().doubleValue();
+    try {
+      return JsonNumericParser.parseAsNumber(this.inner);
+    } catch (final IllegalArgumentException e) {
+      // Convert to IllegalStateException for consistency with other 'as' methods
+      throw new IllegalStateException(
+          "Cannot convert value to number: " + (this.inner != null ? this.inner.toString() : "null"), e);
+    }
   }
+
+  /**
+   * Returns the long value of this JSONValue.
+   * Delegates to asNumber() and casts the result to long.
+   * 
+   * @return The long value.
+   * @throws IllegalStateException if the value cannot be converted to a number.
+   */
+  public Long asLong() {
+    // Rely on asNumber for parsing logic (including strings like "Infinity")
+    // Note: Casting Infinity/NaN to long results in Long.MAX_VALUE/MIN_VALUE/0
+    // respectively.
+    return asNumber().longValue();
+  }
+
 
   public boolean isObject() {
-    return inner.isObject() != null;
+    return inner != null && inner.isObject() != null;
   }
 
   public JSONObjectHandle asObjectHandle() {
+    if (inner == null || inner.isObject() == null) {
+      throw new IllegalStateException("Value is not an Object");
+    }
     return new JSONObjectHandle(inner.isObject());
   }
 
   public boolean isArray() {
-    return inner.isArray() != null;
+    return inner != null && inner.isArray() != null;
   }
 
   public JSONArrayHandle asArray() {
+    if (inner == null || inner.isArray() == null) {
+      throw new IllegalStateException("Value is not an Array");
+    }
     return new JSONArrayHandle(inner.isArray());
   }
 
+  /**
+   * Checks if this JSONValue represents a number.
+   * Delegates to JsonNumericParser.isRepresentingNumber.
+   *
+   * @return true if the value is a JSONNumber or a special FP string, false
+   *         otherwise.
+   */
   public boolean isNumber() {
-    return inner.isNumber() != null;
+    return JsonNumericParser.isRepresentingNumber(this.inner);
   }
 
   public boolean isBoolean() {
-    return inner.isBoolean() != null;
+    return inner != null && inner.isBoolean() != null;
+  }
+
+  public boolean asBoolean() {
+    if (inner == null || inner.isBoolean() == null) {
+      throw new IllegalStateException("Value is not a Boolean");
+    }
+    return inner.isBoolean().booleanValue();
   }
 
   public boolean isNull() {
-    return inner.isNull() != null;
+    return inner == null || inner.isNull() != null;
   }
+
 }

--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JsonNumericParser.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JsonNumericParser.java
@@ -1,0 +1,63 @@
+package nl.aerius.wui.service.json;
+
+import com.google.gwt.json.client.JSONNumber;
+import com.google.gwt.json.client.JSONString;
+import com.google.gwt.json.client.JSONValue;
+
+/**
+ * Helper for parsing JSONValues that might represent numbers,
+ * including special string cases ("Infinity", "-Infinity", "NaN").
+ */
+class JsonNumericParser {
+
+  /**
+   * Checks if the value is a JSONNumber or a special FP string ("Infinity",
+   * "-Infinity", "NaN").
+   * 
+   * @param value The JSONValue to check (can be null).
+   */
+  static boolean isRepresentingNumber(final JSONValue value) {
+    if (value == null) {
+      return false;
+    }
+    if (value.isNumber() != null) {
+      return true;
+    }
+    final JSONString jsonString = value.isString();
+    if (jsonString != null) {
+      try {
+        final double parsedValue = Double.parseDouble(jsonString.stringValue());
+        return Double.isInfinite(parsedValue) || Double.isNaN(parsedValue);
+      } catch (final NumberFormatException e) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Parses the JSONValue as a Double, handling JSONNumber and JSONString.
+   * Supports special strings "Infinity", "-Infinity", "NaN".
+   *
+   * @param value The JSONValue to parse.
+   * @throws IllegalArgumentException if parsing is not possible.
+   */
+  static Double parseAsNumber(final JSONValue value) throws IllegalArgumentException {
+    if (value == null) {
+      throw new IllegalArgumentException("Cannot parse null JSONValue as number");
+    }
+    final JSONNumber num = value.isNumber();
+    if (num != null) {
+      return num.doubleValue();
+    }
+    final JSONString str = value.isString();
+    if (str != null) {
+      try {
+        return Double.parseDouble(str.stringValue());
+      } catch (final NumberFormatException e) {
+        throw new IllegalArgumentException("String value is not parsable as double: [" + str.stringValue() + "]", e);
+      }
+    }
+    throw new IllegalArgumentException("JSONValue is neither JSONNumber nor JSONString, cannot parse as number.");
+  }
+}


### PR DESCRIPTION
So basically, sometimes a `Double` is formatted as a `String` in json, so as to convey things like `-Infinity`, `Infinity`, or `NaN`. This makes sense. However we need to still be able to parse those strings as doubles, aswell as make the "isNumber" expressions clue us in that they are numbers. However due to the way the GWT json parsing library and this wrapper works, it isn't very simple to obtain this kind of information elegantly, because it basically just wraps JsonNode which tells us whether the json node is a string or a number etc. which is not really open to interpretation. But thankfully, this being a wrapper which wraps calls to JsonNode stuff for syntactic convenience, we can just do the interpretation in the part which wraps it!

So long story short: lots of code to achieve this tiny thing.