### PR TITLE
Add Legend subtype info and ColorRangesLegend

### DIFF
--- a/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorItem.java
+++ b/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorItem.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.geo.domain.legend;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ColorItem implements Serializable, Comparable<ColorItem> {
+  private static final long serialVersionUID = 1L;
+
+  private String color;
+  private int lineWidth;
+  private String itemValue;
+  private @JsonProperty int sortOrder;
+
+  /**
+   * Default constructor.
+   */
+  public ColorItem() {
+    // GWT required constructor.
+  }
+
+  /**
+   * @param itemValue The value for this item.
+   * @param color     The color to use for this item.
+   * @param sortOrder The sorting order to use.
+   */
+  public ColorItem(final String itemValue, final String color, final int lineWidth, final int sortOrder) {
+    this.itemValue = itemValue;
+    this.color = color;
+    this.lineWidth = lineWidth;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ColorItem that = (ColorItem) o;
+    return Objects.equals(itemValue, that.itemValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(itemValue);
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public int getLineWidth() {
+    return lineWidth;
+  }
+
+  public String getItemValue() {
+    return itemValue;
+  }
+
+  @Override
+  public String toString() {
+    return "ColorRange{" +
+        "color='" + color + '\'' +
+        "lineWidth=" + lineWidth +
+        ", itemValue=" + itemValue +
+        '}';
+  }
+
+  @Override
+  public int compareTo(final ColorItem item) {
+    return Integer.compare(sortOrder, item.sortOrder);
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setColor(final String color) {
+    this.color = color;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setLineWidth(final int lineWidth) {
+    this.lineWidth = lineWidth;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setItemValue(final String itemValue) {
+    this.itemValue = itemValue;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setSortOrder(final int sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+}

--- a/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorRange.java
+++ b/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorRange.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.geo.domain.legend;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ColorRange implements Serializable, Comparable<ColorRange> {
+  private static final long serialVersionUID = 1L;
+
+  private String color;
+  private double lowerValue;
+  private String label;
+
+  /**
+   * Default constructor.
+   */
+  public ColorRange() {
+    // GWT required constructor.
+  }
+
+  /**
+   * @param lowerValue The lower value for this range.
+   * @param color      The color to use for this range.
+   */
+  public ColorRange(final double lowerValue, final String color) {
+    this.lowerValue = lowerValue;
+    this.color = color;
+  }
+
+  /**
+   * @param lowerValue The lower value for this range.
+   * @param color      The color to use for this range.
+   * @param label      (Optional) Label to use for this range.
+   */
+  public ColorRange(final double lowerValue, final String color, final String label) {
+    this.lowerValue = lowerValue;
+    this.color = color;
+    this.label = label;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ColorRange that = (ColorRange) o;
+    return Double.compare(that.lowerValue, lowerValue) == 0
+        && Objects.equals(color, that.color)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(color, lowerValue, label);
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setColor(final String color) {
+    this.color = color;
+  }
+
+  public double getLowerValue() {
+    return lowerValue;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setLowerValue(final double lowerValue) {
+    this.lowerValue = lowerValue;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * @deprecated for parsing purposes only
+   */
+  @Deprecated
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String toString() {
+    return "ColorRange{" +
+        "color='" + color + '\'' +
+        ", lowerValue=" + lowerValue +
+        ", label='" + label + '\'' +
+        '}';
+  }
+
+  @Override
+  public int compareTo(final ColorRange range) {
+    return Double.compare(getLowerValue(), range.getLowerValue());
+  }
+}

--- a/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorRangesLegend.java
+++ b/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/ColorRangesLegend.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.geo.domain.legend;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Legend that is extracted from a color range
+ */
+public class ColorRangesLegend extends ColorLabelsLegend {
+  private static final long serialVersionUID = 1L;
+  private static final String LOWER_THAN = "< ";
+  private static final String EQUALS_OR_HIGHER_THAN = "≥ ";
+  private static final String SPACE = " ";
+
+  public ColorRangesLegend() {
+  }
+
+  public ColorRangesLegend(final List<ColorRange> colorRanges, final String rangeText, final LegendType icon) {
+    super(getLabels(colorRanges, v -> v.toString(), rangeText), getColors(colorRanges), icon, null);
+  }
+
+  public ColorRangesLegend(final List<ColorRange> colorRanges, final String rangeText, final LegendType icon,
+      final String unit) {
+    super(getLabels(colorRanges, v -> v.toString(), rangeText), getColors(colorRanges), icon, unit);
+  }
+
+  public ColorRangesLegend(final List<ColorRange> colorRanges, final Function<Double, String> labelDeducer,
+      final String rangeText,
+      final LegendType icon, final String unit) {
+    super(getLabels(colorRanges, labelDeducer, rangeText), getColors(colorRanges), icon, unit);
+  }
+
+  private static String[] getLabels(final List<ColorRange> colorRanges, final Function<Double, String> labelDeducer,
+      final String rangeText) {
+    final String[] labels = new String[colorRanges.size()];
+    for (int i = 0; i < colorRanges.size(); i++) {
+      if (colorRanges.get(i).getLabel() != null) {
+        labels[i] = colorRanges.get(i).getLabel();
+      } else {
+        // Otherwise try to deduce the label from the range
+        labels[i] = deduceLabel(colorRanges, labelDeducer, i, rangeText);
+      }
+    }
+    return labels;
+  }
+
+  private static String deduceLabel(final List<ColorRange> colorRanges, final Function<Double, String> labelDeducer,
+      final int index, final String rangeText) {
+    final String spacedRangeText = SPACE + rangeText + SPACE;
+    if (index != colorRanges.size() - 1) {
+      if (Double.isInfinite(-colorRanges.get(index).getLowerValue())) {
+        return LOWER_THAN + labelDeducer.apply(colorRanges.get(index + 1).getLowerValue());
+      } else {
+        return labelDeducer.apply(colorRanges.get(index).getLowerValue()) + spacedRangeText
+            + labelDeducer.apply(colorRanges.get(index + 1).getLowerValue());
+      }
+    } else {
+      return EQUALS_OR_HIGHER_THAN + labelDeducer.apply(colorRanges.get(index).getLowerValue());
+    }
+  }
+
+  private static String[] getColors(final List<ColorRange> colorRanges) {
+    return colorRanges.stream().map(ColorRange::getColor).toArray(String[]::new);
+  }
+
+}

--- a/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/Legend.java
+++ b/gwt-shared-geo-common/src/main/java/nl/aerius/geo/domain/legend/Legend.java
@@ -18,7 +18,25 @@ package nl.aerius.geo.domain.legend;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
 /**
  * Data class for properties of a layer legend with only a name.
  */
-public interface Legend extends Serializable {}
+@JsonTypeInfo(property = Legend.LEGEND_TYPE_PROPERTY, use = Id.NAME)
+@JsonSubTypes({
+    @Type(value = MarkerLabelsLegend.class, name = Legend.TYPE_MARKER_LABELS),
+    @Type(value = TextLegend.class, name = Legend.TYPE_TEXT),
+    @Type(value = ColorLabelsLegend.class, name = Legend.TYPE_COLOR_LABELS),
+    @Type(value = ColorRangesLegend.class, name = Legend.TYPE_COLOR_RANGES),
+})
+public interface Legend extends Serializable {
+  public static final String LEGEND_TYPE_PROPERTY = "legendType";
+  public static final String TYPE_MARKER_LABELS = "MARKER_LABELS";
+  public static final String TYPE_TEXT = "TEXT";
+  public static final String TYPE_COLOR_LABELS = "COLOR_LABELS";
+  public static final String TYPE_COLOR_RANGES = "COLOR_RANGES";
+}


### PR DESCRIPTION
ColorRangesLegend would formerly reside in `aerius-commons-shared` where it was not available for json serialisation.

Version bump not necessary because this is just a bunch of extra classes.