### PR TITLE
Bump vue-gwt to 1.1.0-AERIUS-1 and adopt aerius-root-pom 1.4.0-SNAPSHOT (GWT 2.13.1)

### DIFF
--- a/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidationOptions.java
+++ b/gwt-vuelidate/sources/src/main/java/nl/aerius/vuelidate/ValidationOptions.java
@@ -64,7 +64,6 @@ public abstract class ValidationOptions<T extends IsVueComponent> implements Cus
     final Map<String, String> mappings = new HashMap<>();
 
     constructValidators(instance, (name, marker, validator) -> {
-      log("Installing validator: " + name);
       final String fieldName = VueGWTTools.getFieldName(instance, marker);
       validations.set(fieldName, validator);
       mappings.put(name, fieldName);
@@ -73,10 +72,6 @@ public abstract class ValidationOptions<T extends IsVueComponent> implements Cus
     options.set("validations", validations);
     options.set("mappings", mappings);
   }
-
-  public static native void log(Object message) /*-{
-    console.info(message);
-  }-*/;
 
   /**
    * <p>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>aerius-root-pom</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vue.version>1.0.1</vue.version>
-    <aerius.vue.version>1.1.0-AERIUS</aerius.vue.version>
+    <aerius.vue.version>1.1.0-AERIUS-1</aerius.vue.version>
     <aerius.shared-geo.version>6.0.1-2</aerius.shared-geo.version>
 
     <org.gwtproject.version>2.12.1</org.gwtproject.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,6 @@
     <gwt.gin.version>2.1.2</gwt.gin.version>
     <gwt.eventbinder.version>1.1.0</gwt.eventbinder.version>
     <gwt-ol3.version>8.5.0</gwt-ol3.version>
-    
-    <gwt-maven-plugin.version>1.1.0</gwt-maven-plugin.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>aerius-root-pom</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -71,7 +71,6 @@
     <aerius.vue.version>1.1.0-AERIUS-1</aerius.vue.version>
     <aerius.shared-geo.version>6.0.1-2</aerius.shared-geo.version>
 
-    <org.gwtproject.version>2.12.1</org.gwtproject.version>
     <elemental2.verion>1.2.3</elemental2.verion>
     <guava.version>33.4.0-jre</guava.version>
     <!-- Keep guice on 6.0.0, 7.0.0 doesn't seem to work with GWT gin -->


### PR DESCRIPTION
Three related version moves:

- vue-gwt annotation processor 1.1.0-AERIUS -> 1.1.0-AERIUS-1 (the "construct each VueComponentFactory once instead of twice" fix; flows to consumers via gwt-client-common-bom).
- aerius-root-pom parent 1.2.0 -> 1.4.0-SNAPSHOT.
- Drop the local org.gwtproject.version; it now comes from the root pom (2.13.1), so the GWT compiler version can no longer drift between gwt-client-common and the calculator.

Depends on aerius/aerius-root-pom#69 (needs root-pom 1.4.0-SNAPSHOT deployed with org.gwtproject.version).