### PR TITLE
[github-actions] Use new init function

### DIFF
--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -9,13 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out github-actions repo
-        uses: actions/checkout@v4
-        with:
-          repository: aerius/github-actions
-          path: aerius-github-actions
-          ref: v1.1
+      - name: Init the github-actions repo
+        uses: aerius/github-actions/init@v1.1
 
-      - uses: aerius/github-actions/events/pull_request-event-action@v1.1
+      - uses: ./aerius-github-actions/events/pull_request-event-action
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -8,14 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out github-actions repo
-        uses: actions/checkout@v4
-        with:
-          repository: aerius/github-actions
-          path: aerius-github-actions
-          ref: v1.1
+      - name: Init the github-actions repo
+        uses: aerius/github-actions/init@v1.1
 
-      - uses: aerius/github-actions/events/push-event-action@v1.1
+      - uses: ./aerius-github-actions/events/push-event-action
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -9,14 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out github-actions repo
-        uses: actions/checkout@v4
-        with:
-          repository: aerius/github-actions
-          path: aerius-github-actions
-          ref: v1.1
+      - name: Init the github-actions repo
+        uses: aerius/github-actions/init@v1.1
 
-      - uses: aerius/github-actions/events/release-event-action@v1.1
+      - uses: ./aerius-github-actions/events/release-event-action
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Gets rid of the custom checkout that we need to keep updated and optionally multiple references to the version of (aerius-)github-actions.