### PR TITLE
AER-4590 Avoid redundant work in JSONObjectHandle

### DIFF
--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONObjectHandle.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONObjectHandle.java
@@ -74,7 +74,7 @@ public class JSONObjectHandle {
 
   public String getStringOrDefault(final String key, final String devault) {
     try {
-      return new JSONObjectHandle(inner).getString(key);
+      return getString(key);
     } catch (final IllegalStateException e) {
       return devault;
     }
@@ -162,7 +162,7 @@ public class JSONObjectHandle {
   }
 
   public boolean has(final String key) {
-    return getInner() != null && keySet() != null && keySet().contains(key);
+    return inner != null && key != null && inner.containsKey(key);
   }
 
   public Optional<JSONArrayHandle> getArrayOptional(final String key) {


### PR DESCRIPTION
This contains some proven non-controversial optimizations in the JSON parser framework.

---
<details>
<summary>LLM-generated technical summary</summary>

Two changes in `JSONObjectHandle`, both provably equivalent.

**`has()` enumerated the object twice per call.** It was:

```java
return getInner() != null && keySet() != null && keySet().contains(key);
```

`keySet()` delegates to GWT's `JSONObject.keySet()`, which on every call runs a full `for-in` with `hasOwnProperty`, allocating a fresh `String[]` and an anonymous `AbstractSet`. Nothing is cached — `size()` even carries a comment about having to recheck for foreign changes.

Crucially, the returned set overrides `contains` to delegate straight back to `containsKey`, so the key array it just built is never read:

```java
public boolean contains(Object o) {
  return (o instanceof String) && containsKey((String) o);
}
```

So both enumerations were pure waste, and `inner.containsKey(key)` reaches the identical native `key in jsObject`. Equivalence holds by construction rather than by argument, including for keys whose value is JSON null and for prototype-chain names such as `toString` (which `has()` already reported as present — that pre-existing quirk is preserved).

`keySet()` can never return null, so that guard was dead. A `key != null` check was added to keep `has(null)` returning false: without it, `null in jsObject` coerces to the property name `"null"`.

In one AERIUS Calculator boot this is called ~15,400 times, so ~30,800 object enumerations disappear.

**`getStringOrDefault` allocated a wrapper around its own state.** It called `new JSONObjectHandle(inner).getString(key)`. `inner` is the class's only field and the constructor merely assigns it, so the new instance was identical to `this`; `getString(key)` is the same call without the allocation.

Verified against the GWT sources shipped in `org.gwtproject:gwt-user:2.13.1`; `JSONObject.java` is byte-identical across 2.10.0, 2.12.1, 2.13.0 and 2.13.1, so this does not depend on the GWT version in use.

Two things a reviewer should know. The module contains no test files, so `mvn test` passes having run nothing — compilation is the only automated evidence here, and real validation is a client boot. And the runtime saving has not been measured in a browser; the change is justified by strictly removing work, not by a benchmark.
</details>
