### PR TITLE
fix NPE in getBoolean when the value is json null

### DIFF
--- a/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONObjectHandle.java
+++ b/gwt-client-common-json/src/main/java/nl/aerius/wui/service/json/JSONObjectHandle.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.google.gwt.json.client.JSONArray;
+import com.google.gwt.json.client.JSONBoolean;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONString;
@@ -153,12 +154,12 @@ public class JSONObjectHandle {
   }
 
   public boolean getBoolean(final String key) {
-    final JSONValue bool = inner.get(key);
+    final JSONBoolean bool = getValue(key).isBoolean();
     if (bool == null) {
-      throw new IllegalStateException("Wrongly assumed json value to be Number while it was not: [" + key + "] in " + inner);
+      throw new IllegalStateException("Wrongly assumed json value to be Boolean while it was not: [" + key + "] in " + inner);
     }
 
-    return bool.isBoolean().booleanValue();
+    return bool.booleanValue();
   }
 
   public boolean has(final String key) {


### PR DESCRIPTION
Fixes a couple of small bugs that we haven't actually run into yet.

---
<details>
<summary>LLM-generated technical summary</summary>

`inner.get(key)` returns Java `null` only when the key is absent. A JSON `null` comes back as `JSONNull.getInstance()`, which is non-null, so the guard passed and `isBoolean()` then returned `null`, making `booleanValue()` throw an NPE. `{"someFlag": null}` crashes today.

The replacement is the shape `getString`, `getNumber` and `getArray` already use: resolve through `getValue(key)`, narrow with `isBoolean()`, and null-check the narrowed value. The message also said "Number" in the boolean accessor, which is the second fix.

One behaviour change beyond the NPE: for an absent key this now throws `getValue`'s "Did not encounter required field in object" instead of the misleading "Wrongly assumed json value to be Number". Same exception type, and consistent with the sibling accessors.

Note the module has no test files, so `mvn test` passes having run nothing — compilation is the only automated evidence here.
</details>
